### PR TITLE
Fix tournament storage and Pydantic defaults

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,11 +1,10 @@
 import logging
 import random
-from http.client import HTTPException
 from typing import Dict
 
-from fastapi import FastAPI
-from starlette.middleware.cors import CORSMiddleware
+from fastapi import FastAPI, HTTPException
 from fastapi.requests import Request
+from starlette.middleware.cors import CORSMiddleware
 from starlette.responses import JSONResponse
 
 from backend.models.models import Tournament, Player, MatchResult, Info
@@ -37,15 +36,15 @@ async def root():
 
 @app.post("/createTournament")
 async def create_tournament(tournament: Tournament):
+    if tournament.code is None:
+        prefix = tournament.name[:2]
+        code_number = random.randint(1000, 9999)
+        tournament.code = prefix + str(code_number)
+
     if tournament.code in tournaments:
         raise HTTPException("Tournament already exists")
 
-    if tournament.code is None:
-        code = tournament.name[:2]
-        code_numebr = random.randint(1000,9999)
-        tournament.code = code + str(code_numebr)
-
-    tournaments[tournament.name] = tournament
+    tournaments[tournament.code] = tournament
     return {"message": "Tournament created", "tournaments": list(tournaments.keys())}
 
 
@@ -77,6 +76,4 @@ async def submit_result(request: MatchResult):
 
 
 def find_tournament(code: str):
-    for tournament in tournaments.values():
-        if tournament.code == code:
-            return tournament
+    return tournaments.get(code)

--- a/backend/models/models.py
+++ b/backend/models/models.py
@@ -1,6 +1,6 @@
-from typing import List
+from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class MatchResult(BaseModel):
@@ -18,8 +18,8 @@ class Player(BaseModel):
 
 class Tournament(BaseModel):
     name: str
-    code: str = None
+    code: Optional[str] = None
     tables: List[int]
-    players: List[Player] = []
+    players: List[Player] = Field(default_factory=list)
     max_players: int = 30
 


### PR DESCRIPTION
## Summary
- fix HTTPException import
- generate code before checking for duplicates and store tournaments by code
- use default_factory for Tournament players list
- simplify find_tournament lookup

## Testing
- `python -m py_compile backend/main.py backend/models/models.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6841afd2c658832087a700d508d4a3ef